### PR TITLE
Update to Support PHP 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Latest Unstable Version](https://poser.pugx.org/eig/eloquent-uuid/v/unstable)](https://packagist.org/packages/eig/eloquent-uuid) 
 
 
-A Package for easily adding UUID's to Eloquent Models
+A Package for easily adding UUID's to Eloquent Models supporting Laravel 5.1, 5.2, and 5.3
 
 ## Usage
 To use UUID in an Eloquent Model install the package with:
@@ -44,7 +44,7 @@ public function up()
 ```
 
 ## Supported PHP Versions
-- 5.6
+- 5.6+
+- 7.0
 - hhvm
 
-PHP 7 support planned for the future in conjunction with a dependency's support for PHP 7.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then in your migrations make sure you set id to string or uuid like this:
 ```
 public function up()
     {
-        Schema::create('lient_models', function (Blueprint $table) {
+        Schema::create('client_models', function (Blueprint $table) {
             $table->uuid('id');
             $table->softDeletes();
             $table->timestamps();

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
 
   },
   "require-dev": {
-    "phpunit/phpunit": "~5.2",
+    "phpunit/phpunit": "~5.6",
     "mockery/mockery": "^0.9.4",
     "satooshi/php-coveralls": "dev-master",
-    "apostle/phpunit-validation": "@dev"
+    "apostle/phpunit-validation": "1.0.*@dev"
   },
   "autoload": {
     "psr-4": {

--- a/tests/EloquentUUIDTest.php
+++ b/tests/EloquentUUIDTest.php
@@ -39,6 +39,4 @@ class EloquentUUIDTest extends TestCase
     {
         return new IsUuid($strict, $versions);
     }
-
-
 }

--- a/tests/EloquentUUIDTest.php
+++ b/tests/EloquentUUIDTest.php
@@ -2,8 +2,9 @@
 
 namespace eig\EloquentUUID\Tests;
 
-use Apostle\PHPUnit\TestCase;
+use PHPUnit\Framework\TestCase;
 use eig\EloquentUUID\UUIDModel;
+use Apostle\PHPUnit\Constraint\String\IsUuid;
 
 /**
  * Class EloquentUUIDTest
@@ -14,7 +15,6 @@ use eig\EloquentUUID\UUIDModel;
  */
 class EloquentUUIDTest extends TestCase
 {
-
     /**
      * testHasUUID
      */
@@ -23,4 +23,22 @@ class EloquentUUIDTest extends TestCase
         $model = new UUIDModel();
         $this->assertUuid($model->id);
     }
+
+    /**
+     * functions added because of a lack of support for PHP 7
+     * by the phpunit-validation package that checks the UUID
+     * if support is added in the package these functions will not
+     * be necessary.
+     */
+    public function assertUuid($value, $strict = false, array $versions = array(1, 2, 3, 4, 5), $message = '')
+    {
+        self::assertThat($value, self::isUuid($strict, $versions), $message);
+    }
+
+    public static function isUuid($strict = false, array $versions = array(1, 2, 3, 4, 5))
+    {
+        return new IsUuid($strict, $versions);
+    }
+
+
 }


### PR DESCRIPTION
PHP 7 is now supported through manually implementing some tests that were from an incompatible package.
