### PR TITLE
Update package to require a min of PHP 7.1 

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,3 @@
 preset: psr2
 
 risky: true
-
-linting: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Latest Unstable Version](https://poser.pugx.org/eig/eloquent-uuid/v/unstable)](https://packagist.org/packages/eig/eloquent-uuid) 
 
 
-A Package for easily adding UUID's to Eloquent Models supporting Laravel 5.1, 5.2, and 5.3
+A Package for easily adding UUID's to Eloquent Models supporting Laravel 5.5+
 
 ## Usage
 To use UUID in an Eloquent Model install the package with:
@@ -57,5 +57,5 @@ As of version 1.1.0, EloquentUUID now has a trait named `UUID` in the namespace 
 ## Supported PHP Versions
 - 5.6+ Use the [1.x branch releases](https://github.com/excellentingenuity/EloquentUUID/releases/tag/1.1.1)
 - 7.0 Use the [master branch releases of 2.x+](https://github.com/excellentingenuity/EloquentUUID/releases/tag/2.0.0)
-- 7.1 Use the [master branch releases of 2.x+](https://github.com/excellentingenuity/EloquentUUID/releases/tag/2.0.0)
+- 7.1+ Use the [master branch releases of 2.1+](https://github.com/excellentingenuity/EloquentUUID/releases/tag/2.1.0)
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "wiki": "https://github.com/excellentingenuity/EloquentUUID/wiki"
   },
   "require": {
-    "php": ">=7.0",
+    "php": ">=7.1",
     "eig/UUID": "^2.1.0"
 
 

--- a/composer.json
+++ b/composer.json
@@ -19,16 +19,16 @@
   },
   "require": {
     "php": ">=7.0",
-    "eig/UUID": "^2.0.0"
+    "eig/UUID": "^2.1.0"
 
 
   },
   "require-dev": {
-    "phpunit/phpunit": "~6.2",
+    "phpunit/phpunit": "~7.0",
     "mockery/mockery": "dev-master",
-    "satooshi/php-coveralls": "^1.0",
+    "php-coveralls/php-coveralls": "^2.1",    
     "symfony/translation": "3.1.7",
-    "laravel/framework": "5.4"
+    "laravel/framework": "5.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="EloquentUUID Test Suite">
             <directory suffix=".php">./tests/</directory>
@@ -17,6 +16,7 @@
     <filter>
         <whitelist>
             <directory suffix=".php">src/</directory>
+            <directory suffix=".php">tests/Fixtures</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/UUIDUserTest.php
+++ b/tests/UUIDUserTest.php
@@ -5,6 +5,7 @@ namespace eig\EloquentUUID\Tests;
 use eig\UUID\Traits\IsUUID;
 use PHPUnit\Framework\TestCase;
 use eig\EloquentUUID\Tests\Fixtures\UUIDUserModel;
+
 /**
  * Class UUIDUserTest
  * @package eig\EloquentUUID\Tests

--- a/tests/UUIDUserTest.php
+++ b/tests/UUIDUserTest.php
@@ -5,7 +5,6 @@ namespace eig\EloquentUUID\Tests;
 use eig\UUID\Traits\IsUUID;
 use PHPUnit\Framework\TestCase;
 use eig\EloquentUUID\Tests\Fixtures\UUIDUserModel;
-
 /**
  * Class UUIDUserTest
  * @package eig\EloquentUUID\Tests


### PR DESCRIPTION
The package is updated to require PHP 7.1 minimum. Additionally, the dependencies have all been updated and support for Laravel 5.5+. Laravel 5.2 to 5.4 is still possible but not officially supported.